### PR TITLE
generate "!$OMP END parallel do" for Fortran tests

### DIFF
--- a/src/template/hierarchical_parallelism.F90.jinja2
+++ b/src/template/hierarchical_parallelism.F90.jinja2
@@ -182,7 +182,7 @@ END DO
    {% filter indent(width=2*loop.revindex) %}
          {% for pragma in region | reverse %}
       {% if paired_pragmas or not loop_constructs or not loop.first %}
-!$OMP END {{pragma}}
+!$OMP END {{pragma | replace("for","do")}}
       {% endif %}
          {% endfor %}
    {% endfilter %}


### PR DESCRIPTION
The Fortran hierarchical_parallelism tests were correctly generating
"!$OMP parallel do" for construct start, but construct end was being
incorrectly generated as "!$OMP END parallel for".  Fix in the same
way the start construct is handled, by replacing "for" with "do".