### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ jobs:
         - intel-oneapi-icc
         - python3
     install:
-    - source /opt/intel/inteloneapi/compiler/latest/env/vars.sh
+    - source /opt/intel/oneapi/setvars.sh
     script:
     - ./ovo.sh run test_src/cpp
     - ./ovo.sh report --failed || true
@@ -150,7 +150,7 @@ jobs:
         - intel-oneapi-ifort
         - python3
     install:
-    - source /opt/intel/inteloneapi/compiler/latest/env/vars.sh
+    - source /opt/intel/oneapi/setvars.sh
     script:
     - ./ovo.sh run test_src/fortran
     - ./ovo.sh report --failed || true


### PR DESCRIPTION
Right now there's a travis-CI error:

```
$ source /opt/intel/inteloneapi/compiler/latest/env/vars.sh
/home/travis/.travis/functions: line 109: /opt/intel/inteloneapi/compiler/latest/env/vars.sh: No such file or directory
The command "source /opt/intel/inteloneapi/compiler/latest/env/vars.sh" failed and exited with 1 during .
```

It looks like the right thing to source is `source /opt/intel/oneapi/setvars.sh` now. 

This PR changes `/opt/intel/inteloneapi/compiler/latest/env/vars.sh` to `/opt/intel/oneapi/setvars.sh`, and the error above goes away. The `icx` version passes now, but it looks like `ifx` hangs on a compile right now, so it fails still.