### PR TITLE
Add C++ test_type for reduction_min and reduction_max 

### DIFF
--- a/src/gtest.py
+++ b/src/gtest.py
@@ -606,8 +606,12 @@ class HP:  # ^(;,;)^
                     yield f"map(to: src{borns}) map(from: dst{borns})"
 
         def reduction_directive(counter, pragma):
-            if "reduction" in self.test_type and pragma.can_be_reduced:
+            if "reduction_sum" in self.test_type and pragma.can_be_reduced:
                 yield f"reduction(+: {counter})"
+            elif "reduction_min" in self.test_type and pragma.can_be_reduced:
+                yield f"reduction(min: {counter})"
+            elif "reduction_max" in self.test_type and pragma.can_be_reduced:
+                yield f"reduction(max: {counter})"
 
         def ordered_directive(pragma):
             if "ordered" in self.test_type and pragma.has_construct("ordered"):
@@ -1087,7 +1091,7 @@ def gen_all_permutation(d_args):
 #                                  _|
 
 hp_d_possible_value = {
-    "test_type": {"memcopy", "atomic", "reduction", "ordered"},
+    "test_type": {"memcopy", "atomic", "reduction_sum", "reduction_min", "reduction_max", "ordered"},
     "data_type": {"REAL", "DOUBLE PRECISION", "float", "double", "complex<float>", "complex<double>", "COMPLEX", "DOUBLE COMPLEX"},
     "loop_pragma": bool,
     "paired_pragmas": bool,
@@ -1100,7 +1104,7 @@ hp_d_possible_value = {
 }
 
 hp_d_default_value = defaultdict(lambda: False)
-hp_d_default_value.update({"data_type": {"REAL", "float"}, "test_type": {"memcopy", "atomic", "reduction"}, "collapse": [0], "tripcount": [32 * 32 * 32]})
+hp_d_default_value.update({"data_type": {"REAL", "float"}, "test_type": {"memcopy", "atomic", "reduction_sum"}, "collapse": [0], "tripcount": [32 * 32 * 32]})
 
 
 mf_d_possible_value = {"standart": {"gnu", "cpp11", "cpp17", "cpp20", "F77", "gnu"}, "simdize": int, "complex": bool, "long": bool}

--- a/src/gtest.py
+++ b/src/gtest.py
@@ -567,7 +567,7 @@ class HP:  # ^(;,;)^
         [[''], ['map(to: src((i0-1+1)*N1:(i0-1+1)*2*N1)) map(from: dst((i0-1+1)*N1:(i0-1+1)*2*N1)) device(MOD(i0-1+1,omp_get_num_devices()))']]
         >>> HP(["parallel for", "target teams distribute"], {"test_type": "memcopy", "collapse": 2, "data_type": "float", "multiple_devices": True}).regions_additional_pragma
         [['collapse(2)'], ['map(to: pS[(i1+N1*(i0))*N2*N3:N2*N3]) map(from: pD[(i1+N1*(i0))*N2*N3:N2*N3]) device((i1+N1*(i0))%omp_get_num_devices()) collapse(2)']]
-        >>> HP(["target teams distribute"], {"test_type": "reduction", "collapse": 3}).regions_additional_pragma
+        >>> HP(["target teams distribute"], {"test_type": "reduction_sum", "collapse": 3}).regions_additional_pragma
         [['map(tofrom: counter_N0) reduction(+: counter_N0) collapse(3)']]
         """
 

--- a/src/gtest.py
+++ b/src/gtest.py
@@ -569,6 +569,10 @@ class HP:  # ^(;,;)^
         [['collapse(2)'], ['map(to: pS[(i1+N1*(i0))*N2*N3:N2*N3]) map(from: pD[(i1+N1*(i0))*N2*N3:N2*N3]) device((i1+N1*(i0))%omp_get_num_devices()) collapse(2)']]
         >>> HP(["target teams distribute"], {"test_type": "reduction_sum", "collapse": 3}).regions_additional_pragma
         [['map(tofrom: counter_N0) reduction(+: counter_N0) collapse(3)']]
+        >>> HP(["target teams distribute"], {"test_type": "reduction_min", "collapse": 3}).regions_additional_pragma
+        [['map(tofrom: counter_N0) reduction(min: counter_N0) collapse(3)']]
+        >>> HP(["target teams distribute"], {"test_type": "reduction_max", "collapse": 3}).regions_additional_pragma
+        [['map(tofrom: counter_N0) reduction(max: counter_N0) collapse(3)']]
         """
 
         def device_directive(i, counter, pragma):

--- a/src/gtest.py
+++ b/src/gtest.py
@@ -678,7 +678,10 @@ class HP:  # ^(;,;)^
         >>> HP(["for"], {"data_type": "REAL", "collapse": 2}).inner_index
         'i1-1+N1*(i0-1)+1'
         """
-        return self.running_index(self.associated_loops_number)
+        if self.associated_loops_number:
+            return self.running_index(self.associated_loops_number)
+        else:
+            return '0'
 
     @cached_property
     def is_valid_test(self):

--- a/src/template/hierarchical_parallelism.cpp.jinja2
+++ b/src/template/hierarchical_parallelism.cpp.jinja2
@@ -57,7 +57,7 @@ bool almost_equal({{T}} x, {{T}} y, int ulp) {
 bool almost_equal({{T}} x, {{T}} gold, float tol) {
   {# check for same sign #}
   {% if T.is_complex %}
-  if ( (std::signbit(std::real(x)) == std::signbit(std::real(gold)))  && (std::signbit(std::real(x)) == std::signbit(std::real(gold))) ) {
+  if ( (std::signbit(std::real(x)) == std::signbit(std::real(gold))) && (std::signbit(std::imag(x)) == std::signbit(std::imag(gold))) ) {
   {% else %}
   if ( std::signbit(x) == std::signbit(gold) ) {
   {% endif %}

--- a/src/template/hierarchical_parallelism.cpp.jinja2
+++ b/src/template/hierarchical_parallelism.cpp.jinja2
@@ -97,9 +97,9 @@ void test_{{name}}() {
   {{T}} *pS { src.data() };
   {{T}} *pD { dst.data() };
 {% elif test_type == 'reduction_min' %}
-  const {{T}} expected_value { -{{tripcount}} + 1};
+  const {{T}} expected_value { -{{tripcounts}} };
 {% elif test_type == 'reduction_max' %}
-  const {{T}} expected_value { {{tripcounts}} - 1};
+  const {{T}} expected_value { {{tripcounts}} };
 {% else %}
   const {{T}} expected_value { {{tripcounts}} };
 {% endif %}
@@ -147,9 +147,9 @@ for (int {{loop_.i}} = 0 ; {{loop_.i}} < {{loop_.N}} ; {{loop_.i}}++ )
          {# Perform min and max using ternerary operators #}
          {# Reductions are special case and need to be in the front #}
          {% if test_type == 'reduction_min' %}
-{{increments.v}} = (({{increments.v}} < -({{inner_index}})) ? {{increments.v}} : -({{inner_index}}));
+{{increments.v}} = (({{increments.v}} < -({{inner_index}} + 1)) ? {{increments.v}} : -({{inner_index}} + 1));
          {% elif test_type == 'reduction_max' %}
-{{increments.v}} = (({{increments.v}} >  {{inner_index}}) ? {{increments.v}} : {{inner_index}});
+{{increments.v}} = (({{increments.v}} >  ({{inner_index}} + 1)) ? {{increments.v}} :  ({{inner_index}} + 1));
          {# Complex #}
          {% elif T.is_complex and increments.j and increments.i != "1." %}
 {{increments.v}} = {{increments.v}} + {{T}} { {{increments.i}}.real() / {{increments.j}} };

--- a/src/template/hierarchical_parallelism.cpp.jinja2
+++ b/src/template/hierarchical_parallelism.cpp.jinja2
@@ -78,8 +78,17 @@ bool almost_equal({{T}} x, {{T}} gold, float tol) {
 {#  \_/\___||___/\__| \_|  \__,_|_| |_|\___|\__|_|\___/|_| |_|#}
 {#                                                            #}
 
-{% if test_type == 'reduction_sum' and T.is_complex and not no_user_defined_reduction%}
+{% if T.is_complex and not no_user_defined_reduction %}
+   {% if test_type == 'reduction_sum' %}
 #pragma omp declare reduction(+: {{T}}: omp_out += omp_in)
+   {% elif test_type == 'reduction_min' %}
+   {# reduction_min takes the sign and magnitude into of the complex number into account. #}
+   {# it is sufficient to take the sign of the real component. #}
+#pragma omp declare reduction(min: {{T}}: omp_out = (copysign(1.0, std::real(omp_in))*std::abs(omp_in) < copysign(1.0, std::real(omp_out))*std::abs(omp_out) ? omp_in : omp_out) )
+   {% elif test_type == 'reduction_max' %}
+   {# reduction_max is easier since the counter variable never goes negative #}
+#pragma omp declare reduction(max: {{T}}: omp_out = (std::abs(omp_in) > std::abs(omp_out) ? omp_in : omp_out) )
+   {% endif %}
 {% endif %}
 
 void test_{{name}}() {

--- a/src/template/hierarchical_parallelism.cpp.jinja2
+++ b/src/template/hierarchical_parallelism.cpp.jinja2
@@ -55,8 +55,12 @@ bool almost_equal({{T}} x, {{T}} y, int ulp) {
 {% else %}
 {# handles signed numbers, but doesn't check real and imagine components of complex data type seperately #}
 bool almost_equal({{T}} x, {{T}} gold, float tol) {
-   {# check for same sign #}
-  if ((x < 0) == (gold < 0)) {
+  {# check for same sign #}
+  {% if T.is_complex %}
+  if ( (std::signbit(std::real(x)) == std::signbit(std::real(gold)))  && (std::signbit(std::real(x)) == std::signbit(std::real(gold))) ) {
+  {% else %}
+  if ( std::signbit(x) == std::signbit(gold) ) {
+  {% endif %}
      return std::abs(gold) * (1-tol) <= std::abs(x) && std::abs(x) <= std::abs(gold) * (1 + tol);
   }
   else {
@@ -148,9 +152,9 @@ for (int {{loop_.i}} = 0 ; {{loop_.i}} < {{loop_.N}} ; {{loop_.i}}++ )
          {# Perform min and max using ternerary operators #}
          {# Reductions are special case and need to be in the front #}
          {% if test_type == 'reduction_min' %}
-{{increments.v}} = (({{increments.v}} < -({{inner_index}} + 1)) ? {{increments.v}} : -({{inner_index}} + 1));
+{{increments.v}} = ((std::abs({{increments.v}}) < (-1.0)*std::abs({{inner_index}} + 1)) ? {{increments.v}} : (-1.0)*({{inner_index}} + 1));
          {% elif test_type == 'reduction_max' %}
-{{increments.v}} = (({{increments.v}} >  ({{inner_index}} + 1)) ? {{increments.v}} :  ({{inner_index}} + 1));
+{{increments.v}} = ((std::abs({{increments.v}}) >  std::abs(({{inner_index}} + 1))) ? {{increments.v}} :  ({{inner_index}} + 1));
          {# Complex #}
          {% elif T.is_complex and increments.j and increments.i != "1." %}
 {{increments.v}} = {{increments.v}} + {{T}} { {{increments.i}}.real() / {{increments.j}} };

--- a/src/template/hierarchical_parallelism.cpp.jinja2
+++ b/src/template/hierarchical_parallelism.cpp.jinja2
@@ -53,6 +53,7 @@ bool almost_equal({{T}} x, {{T}} y, int ulp) {
    {% endif %}
 }
 {% else %}
+{# we need to enhance this function to support negative gold values for non complex type #}
 bool almost_equal({{T}} x, {{T}} gold, float tol) {
    {% if T.category == "float" %}
   return gold * (1-tol) <= x && x <= gold * (1 + tol);

--- a/src/template/hierarchical_parallelism.cpp.jinja2
+++ b/src/template/hierarchical_parallelism.cpp.jinja2
@@ -142,7 +142,7 @@ for (int {{loop_.i}} = 0 ; {{loop_.i}} < {{loop_.N}} ; {{loop_.i}}++ )
          {% if T.is_complex and increments.j and increments.i != "1." %}
 {{increments.v}} = {{increments.v}} + {{T}} { {{increments.i}}.real() / {{increments.j}} };
          {% elif T.is_complex and increments.j and increments.i == "1." %}
-{{increments.v}} = {{increments.v}} + {{T}} { {{T.internal}} { 1. } / {{increments.j}} }; {# Explicit cast, so compiler doesn't compline about lost of accuracy#}
+{{increments.v}} = {{increments.v}} + {{T}} { {{T.internal}} { 1. } / {{increments.j}} }; {# Explicit cast, so compiler doesn't complain about lost of accuracy#}
          {% elif T.is_complex  %}
 {{increments.v}} = {{increments.v}} + {{T}} { {{increments.i}} };
          {# Real #}

--- a/src/template/hierarchical_parallelism.cpp.jinja2
+++ b/src/template/hierarchical_parallelism.cpp.jinja2
@@ -96,6 +96,10 @@ void test_{{name}}() {
   std::generate(src.begin(), src.end(), std::rand);
   {{T}} *pS { src.data() };
   {{T}} *pD { dst.data() };
+{% elif test_type == 'reduction_min' %}
+  const {{T}} expected_value { -{{tripcount}} + 1};
+{% elif test_type == 'reduction_max' %}
+  const {{T}} expected_value { {{tripcounts}} - 1};
 {% else %}
   const {{T}} expected_value { {{tripcounts}} };
 {% endif %}

--- a/src/template/hierarchical_parallelism.cpp.jinja2
+++ b/src/template/hierarchical_parallelism.cpp.jinja2
@@ -53,13 +53,14 @@ bool almost_equal({{T}} x, {{T}} y, int ulp) {
    {% endif %}
 }
 {% else %}
-{# we need to enhance this function to support negative gold values for non complex type as well as zero #}
+{# handles signed numbers, but doesn't check real and imagine components of complex data type seperately #}
 bool almost_equal({{T}} x, {{T}} gold, float tol) {
-   {% if T.category == "float" %}
-  return gold * (1-tol) <= x && x <= gold * (1 + tol);
-   {% elif T.category == "complex" %}
-  return std::abs(gold) * (1-tol) <= std::abs(x) && std::abs(x) <= std::abs(gold) * (1 + tol);
-   {% endif %}
+   {# check for same sign #}
+  if ((x < 0) == (gold < 0)) {
+     return std::abs(gold) * (1-tol) <= std::abs(x) && std::abs(x) <= std::abs(gold) * (1 + tol);
+} else {
+     return false;
+  }
 }
 {% endif%}
 

--- a/src/template/hierarchical_parallelism.cpp.jinja2
+++ b/src/template/hierarchical_parallelism.cpp.jinja2
@@ -53,7 +53,7 @@ bool almost_equal({{T}} x, {{T}} y, int ulp) {
    {% endif %}
 }
 {% else %}
-{# we need to enhance this function to support negative gold values for non complex type #}
+{# we need to enhance this function to support negative gold values for non complex type as well as zero #}
 bool almost_equal({{T}} x, {{T}} gold, float tol) {
    {% if T.category == "float" %}
   return gold * (1-tol) <= x && x <= gold * (1 + tol);

--- a/src/template/hierarchical_parallelism.cpp.jinja2
+++ b/src/template/hierarchical_parallelism.cpp.jinja2
@@ -58,7 +58,8 @@ bool almost_equal({{T}} x, {{T}} gold, float tol) {
    {# check for same sign #}
   if ((x < 0) == (gold < 0)) {
      return std::abs(gold) * (1-tol) <= std::abs(x) && std::abs(x) <= std::abs(gold) * (1 + tol);
-} else {
+  }
+  else {
      return false;
   }
 }

--- a/src/template/hierarchical_parallelism.cpp.jinja2
+++ b/src/template/hierarchical_parallelism.cpp.jinja2
@@ -143,9 +143,15 @@ for (int {{loop_.i}} = 0 ; {{loop_.i}} < {{loop_.N}} ; {{loop_.i}}++ )
          {% elif test_type == 'ordered' %}
 #pragma omp ordered
          {% endif %}
-          
+
+         {# Perform min and max using ternerary operators #}
+         {# Reductions are special case and need to be in the front #}
+         {% if test_type == 'reduction_min' %}
+{{increments.v}} = (({{increments.v}} < -({{inner_index}})) ? {{increments.v}} : -({{inner_index}}));
+         {% elif test_type == 'reduction_max' %}
+{{increments.v}} = (({{increments.v}} >  {{inner_index}}) ? {{increments.v}} : {{inner_index}});
          {# Complex #}
-         {% if T.is_complex and increments.j and increments.i != "1." %}
+         {% elif T.is_complex and increments.j and increments.i != "1." %}
 {{increments.v}} = {{increments.v}} + {{T}} { {{increments.i}}.real() / {{increments.j}} };
          {% elif T.is_complex and increments.j and increments.i == "1." %}
 {{increments.v}} = {{increments.v}} + {{T}} { {{T.internal}} { 1. } / {{increments.j}} }; {# Explicit cast, so compiler doesn't complain about lost of accuracy#}

--- a/src/template/hierarchical_parallelism.cpp.jinja2
+++ b/src/template/hierarchical_parallelism.cpp.jinja2
@@ -72,7 +72,7 @@ bool almost_equal({{T}} x, {{T}} gold, float tol) {
 {#  \_/\___||___/\__| \_|  \__,_|_| |_|\___|\__|_|\___/|_| |_|#}
 {#                                                            #}
 
-{% if test_type == 'reduction' and T.is_complex and not no_user_defined_reduction%}
+{% if test_type == 'reduction_sum' and T.is_complex and not no_user_defined_reduction%}
 #pragma omp declare reduction(+: {{T}}: omp_out += omp_in)
 {% endif %}
 

--- a/src/template/ovo_usage.txt
+++ b/src/template/ovo_usage.txt
@@ -3,7 +3,7 @@ Usage:
   ovo.sh gen
   ovo.sh gen tiers [1|2|3] 
                    [--tripcount]
-  ovo.sh gen hierarchical_parallelism [--test_type [atomic|reduction|memcopy|ordered]...]
+  ovo.sh gen hierarchical_parallelism [--test_type [atomic|reduction_sum|reduction_min|reduction_max|memcopy|ordered]...]
                                       [--data_type [float|'complex<float>'|
                                                     double|'complex<double>'|
                                                     REAL|COMPLEX|

--- a/src/template/ovo_usage.txt
+++ b/src/template/ovo_usage.txt
@@ -35,5 +35,5 @@ Generate hierarchical_parallelism memcopy test with REAL datatype with loop cons
   ./ovo.sh gen hierarchical_parallelism  --data_type REAL --loop_pragma True --test_type memcopy
 
 Generate hierarchical_parallelism reduction test with REAL, and complex<float> datatype with and without multi-devices support:
-  ./src/gtest.py hierarchical_parallelism  --data_type REAL "complex<float>" --multiple_devices True False --test_type reduction
+  ./src/gtest.py hierarchical_parallelism  --data_type REAL "complex<float>" --multiple_devices True False --test_type reduction_sum
 


### PR DESCRIPTION
Progress towards addressing this issue https://github.com/TApplencourt/OvO/issues/11

For C++,
- `reduction` renamed to `reduction_sum`
- Two new test_type: `reduction_min`, `reduction_max`